### PR TITLE
awes_ekf: initialize the EKF with a tether-consistent wind

### DIFF
--- a/src/awes_ekf/load_data/create_input_from_csv.py
+++ b/src/awes_ekf/load_data/create_input_from_csv.py
@@ -253,6 +253,24 @@ def find_initial_state_vector(
     CD=0.15,
     CS=0,
 ):
+    # Solve the tether shape with the same wind the observation model will
+    # use. With the log profile the wind state is initialized from the guess
+    # interpreted at 10 m reference height, so the observation model sees
+    # the guess scaled up to kite height; solving the shape with the raw
+    # guess instead (as before) left a multi-meter tether pseudo-measurement
+    # residual at the first update (the step-0 "Terminating IEKF: exceeded
+    # max iterations" warning, repeated after every reinitialization).
+    wind_velocity = np.asarray(wind_velocity, dtype=float)
+    solve_wind = wind_velocity
+    if simConfig.log_profile:
+        wvel = (
+            np.linalg.norm(wind_velocity)
+            * np.log(ekf_input.kite_position[2] / z0)
+            / np.log(10 / z0)
+        )
+        wdir = np.arctan2(wind_velocity[1], wind_velocity[0])
+        solve_wind = np.array([wvel * np.cos(wdir), wvel * np.sin(wdir), 0.0])
+
     tether_input = TetherInput(
         kite_position=ekf_input.kite_position,
         kite_velocity=ekf_input.kite_velocity,
@@ -263,7 +281,7 @@ def find_initial_state_vector(
         tether_elevation=ekf_input.tether_elevation_ground,
         tether_azimuth=ekf_input.tether_azimuth_ground,
         tether_length=ekf_input.tether_length,
-        wind_velocity=wind_velocity,
+        wind_velocity=solve_wind,
     )
 
     tether_input = tether.solve_tether_shape(tether_input)
@@ -280,15 +298,15 @@ def find_initial_state_vector(
     x0 = np.vstack((tether_input.kite_position, tether_input.kite_velocity))
 
     if simConfig.log_profile:
-        uf = np.linalg.norm(tether_input.wind_velocity) * kappa / np.log(10 / z0)
-        ground_winddir = np.arctan2(
-            tether_input.wind_velocity[1], tether_input.wind_velocity[0]
-        )
+        # Friction velocity from the original guess at 10 m reference height
+        # (NOT from solve_wind, which is already scaled to kite height).
+        uf = np.linalg.norm(wind_velocity) * kappa / np.log(10 / z0)
+        ground_winddir = np.arctan2(wind_velocity[1], wind_velocity[0])
         x0 = np.append(
             x0, [uf, ground_winddir, 0]
         )  # Initial wind velocity and direction
     else:
-        x0 = np.append(x0, tether_input.wind_velocity)  # Initial wind velocity
+        x0 = np.append(x0, wind_velocity)  # Initial wind velocity
     x0 = np.append(
         x0,
         [


### PR DESCRIPTION
find_initial_state_vector solved the tether shape with the raw wind guess, which the rest of the initialization interprets as the wind at 10 m reference height. The observation model, however, evaluates the tether with the log-profile wind at kite height - at 280 m that is ~48% more wind, a different tether sag, and therefore an initial tether pseudo-measurement residual of ~12 m on a measurement whose standard deviation is 1e-5 m. The first IEKF update has to absorb that inconsistency by iterating, and the effect recurs at every (re)initialization with the kite at altitude.

Solve the shape with the wind guess scaled up to kite height when log_profile is enabled, so the initial state is consistent with the observation model. The friction-velocity state is still computed from the original 10 m guess. Verified: the initial residual at a 280 m test state drops from 11.7 m to ~1e-5 m (matching the C++ port, which carries the same fix), and the settled estimates are unchanged (sample-by-sample agreement with the C++ port at 2e-4 m/s / 5e-3 deg on a 10-minute validation window).

Note: the occasional "Terminating IEKF: exceeded max iterations" warning seen mid-flight is a separate phenomenon (both implementations hit it once around t+90 s on the 2024-06-05 log) and is not removed by this change.